### PR TITLE
Fix MQTT clustering with Nomad + Consul

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ADD bin/build.sh build.sh
 
 RUN ./build.sh $TARGET
 
-
+# ----------------------------------------------------------------------------
 FROM debian:stretch-slim
 
 RUN \

--- a/bin/vernemq.sh
+++ b/bin/vernemq.sh
@@ -162,5 +162,3 @@ trap 'sigterm_handler' SIGTERM
 /vernemq/bin/vernemq console -noshell -noinput $@
 pid=$(ps aux | grep '[b]eam.smp' | awk '{print $2}')
 wait $pid
-
-EOSH

--- a/bin/vernemq.sh
+++ b/bin/vernemq.sh
@@ -80,9 +80,14 @@ if env | grep "DOCKER_VERNEMQ_DISCOVERY_CONSUL" -q; then
 
     consul_vernemq_services_ip=$(curl -s -X GET http://${CONSUL_HOST}:${CONSUL_PORT}/v1/catalog/service/${SVC_NAME} | jq -r '.[] | .ServiceAddress' | tr '\n' ' ')
     for service_addr in $consul_vernemq_services_ip; do
-        info "Will join an existing cluster with discovery node at ${service_addr}"
-        echo "-eval \"vmq_server_cmd:node_join('VerneMQ@${service_addr}')\"" >> /vernemq/etc/vm.args
-        break
+        info "MQTT services found at ${service_addr}"
+    done
+    for service_addr in $consul_vernemq_services_ip; do
+        if [[ "${service_addr}" != "${NODE_NAME_PART2}" ]]; then
+            info "Will join an existing cluster with discovery node at ${service_addr}"
+            echo "-eval \"vmq_server_cmd:node_join('VerneMQ@${service_addr}')\"" >> /vernemq/etc/vm.args
+            break
+        fi
     done
 fi
 


### PR DESCRIPTION
### The issue

If we rely on Nomad’s TCP health checks (or no health checks at all, but who would do that!) to declare our MQTT service in Nomad, the service is registered into Consul _before_ MQTT actually starts! (I believe this is because of the check only verifying if it could talk to that TCP port, and not checking any kind of feedback like we are used to with HTTP health checks)

### The fix

When we prepare to start VerneMQ, we assumed our local IP (not yet part of the cluster) wouldn’t be in the returned list (since we have not started Verne yet). By explicitely filtering this IP out, we make sure that any remaining IP is a valid one. 

### The future

VerneMQ 1.7.0 introduces a new HTTP module ( `vmq_health_http` ) which exposes a `/health` route.
We already planned to upgrade this fork soon. This gives us anothe reason to do it, and be able to leverage that health check (which would improve the quality of our service registration)
