### PR TITLE
Update VerneMQ to current 1.9.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV DOCKER_VERNEMQ_KUBERNETES_LABEL_SELECTOR="app=vernemq" \
 
 RUN apt-get update && \
     apt-get -y install build-essential git libssl-dev && \
-    git clone -b $VERNEMQ_GIT_REF --single-branch --depth 1 $VERNEMQ_REPO .
+    git clone -b $VERNEMQ_GIT_REF $VERNEMQ_REPO .
 
 COPY bin/build.sh build.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM erlang:21 AS build-env
 
 WORKDIR /vernemq-build
 
-ARG VERNEMQ_GIT_REF=1.9.1
+ARG VERNEMQ_GIT_REF=1.9.2
 ARG TARGET=rel
 ARG VERNEMQ_REPO=https://github.com/vernemq/vernemq.git
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN ./build.sh $TARGET
 FROM debian:stretch-slim
 
 RUN apt-get update && \
-    apt-get -y install openssl iproute2 curl jq && \
+    apt-get -y install procps openssl iproute2 curl jq && \
     rm -rf /var/lib/apt/lists/* && \
     addgroup --gid 10000 vernemq && \
     adduser --uid 10000 --system --ingroup vernemq --home /vernemq --disabled-password vernemq

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM erlang:21 AS build-env
 
 WORKDIR /vernemq-build
 
-ARG VERNEMQ_GIT_REF=1.9.0
+ARG VERNEMQ_GIT_REF=1.9.1
 ARG TARGET=rel
 ARG VERNEMQ_REPO=https://github.com/vernemq/vernemq.git
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM erlang:21 AS build-env
 
 WORKDIR /vernemq-build
 
-ARG VERNEMQ_GIT_REF=1.8.0
+ARG VERNEMQ_GIT_REF=1.9.0
 ARG TARGET=rel
 ARG VERNEMQ_REPO=https://github.com/vernemq/vernemq.git
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM erlang:21 AS build-env
 
 WORKDIR /vernemq-build
 
-ARG VERNEMQ_GIT_REF=1.7.1
+ARG VERNEMQ_GIT_REF=1.8.0
 ARG TARGET=rel
 ARG VERNEMQ_REPO=https://github.com/vernemq/vernemq.git
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -2,7 +2,7 @@ FROM erlang:21-alpine AS build-env
 
 WORKDIR /vernemq-build
 
-ARG VERNEMQ_GIT_REF=1.9.0
+ARG VERNEMQ_GIT_REF=1.9.1
 ARG TARGET=rel
 ARG VERNEMQ_REPO=https://github.com/vernemq/vernemq.git
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -2,7 +2,7 @@ FROM erlang:21-alpine AS build-env
 
 WORKDIR /vernemq-build
 
-ARG VERNEMQ_GIT_REF=1.7.1
+ARG VERNEMQ_GIT_REF=1.8.0
 ARG TARGET=rel
 ARG VERNEMQ_REPO=https://github.com/vernemq/vernemq.git
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -12,7 +12,7 @@ ENV DOCKER_VERNEMQ_KUBERNETES_LABEL_SELECTOR="app=vernemq" \
 
 RUN apk --no-cache --update --available upgrade && \
     apk add --no-cache git autoconf build-base bsd-compat-headers cmake openssl-dev bash && \
-    git clone -b $VERNEMQ_GIT_REF --single-branch --depth 1 $VERNEMQ_REPO .
+    git clone -b $VERNEMQ_GIT_REF $VERNEMQ_REPO .
 
 COPY bin/build.sh build.sh
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -2,7 +2,7 @@ FROM erlang:21-alpine AS build-env
 
 WORKDIR /vernemq-build
 
-ARG VERNEMQ_GIT_REF=1.8.0
+ARG VERNEMQ_GIT_REF=1.9.0
 ARG TARGET=rel
 ARG VERNEMQ_REPO=https://github.com/vernemq/vernemq.git
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -2,7 +2,7 @@ FROM erlang:21-alpine AS build-env
 
 WORKDIR /vernemq-build
 
-ARG VERNEMQ_GIT_REF=1.9.1
+ARG VERNEMQ_GIT_REF=1.9.2
 ARG TARGET=rel
 ARG VERNEMQ_REPO=https://github.com/vernemq/vernemq.git
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ When enabling Kubernetes autoclustering, don't set ```DOCKER_VERNEMQ_DISCOVERY_N
 > WAIT_FOR_ERLANG to the number of seconds to wait.
 > ...
 > ```
+If using an vernemq.conf.local file, you can insert a placeholder (`###IPADDRESS###`) in your config to be replaced (at POD creation time) with the actual IP address of the POD vernemq is running on, making VMQ clustering possible.
 
 ### Checking cluster status
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,32 @@ When enabling Kubernetes autoclustering, don't set ```DOCKER_VERNEMQ_DISCOVERY_N
 > ```
 If using an vernemq.conf.local file, you can insert a placeholder (`###IPADDRESS###`) in your config to be replaced (at POD creation time) with the actual IP address of the POD vernemq is running on, making VMQ clustering possible.
 
+### 4. Using [Docker Swarm](https://docs.docker.com/engine/swarm/)
+
+Please follow the official Docker guide to properly setup Swarm cluster with one or more nodes.
+
+Once Swarm is setup you can deploy a VerneMQ stack. The following snippet describes the stack using a `docker-compose.yml` file:
+
+    version: "3.7"
+    services:
+      vmq0:
+        image: erlio/docker-vernemq
+        environment:
+          DOCKER_VERNEMQ_SWARM: 1
+      vmq:
+        image: erlio/docker-vernemq
+        depends_on:
+          - vmq0
+        environment:
+          DOCKER_VERNEMQ_SWARM: 1
+          DOCKER_VERNEMQ_DISCOVERY_NODE: vmq0
+        deploy:
+          replicas: 2
+
+Run `docker stack deploy -c docker-compose.yml my-vernemq-stack` to deploy a 3 node VerneMQ cluster.
+
+Note: Docker Swarm currently lacks the functionality similar to what is called a statefulset in Kubernetes. As a consequence VerneMQ must rely on a specific discovery service (the `vmq0` service above) that is started before the other replicas.
+
 ### Checking cluster status
 
 To check if the above containers have successfully clustered you can issue the ```vmq-admin``` command:

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ When enabling Kubernetes autoclustering, don't set ```DOCKER_VERNEMQ_DISCOVERY_N
 
 ### Checking cluster status
 
-To check if the bove containers have successfully clustered you can issue the ```vmq-admin``` command:
+To check if the above containers have successfully clustered you can issue the ```vmq-admin``` command:
 
     docker exec vernemq1 vmq-admin cluster show
     +--------------------+-------+

--- a/bin/vernemq.sh
+++ b/bin/vernemq.sh
@@ -49,7 +49,7 @@ if env | grep "DOCKER_VERNEMQ_DISCOVERY_KUBERNETES" -q; then
     # Let's get the namespace if it isn't set
     DOCKER_VERNEMQ_KUBERNETES_NAMESPACE=${DOCKER_VERNEMQ_KUBERNETES_NAMESPACE:-`cat /var/run/secrets/kubernetes.io/serviceaccount/namespace`}
     # Let's set our nodename correctly
-    VERNEMQ_KUBERNETES_SUBDOMAIN=${DOCKER_VERNEMQ_KUBERNETES_SUBDOMAIN:-(curl -X GET $insecure --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt https://kubernetes.default.svc.$DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME/api/v1/namespaces/$DOCKER_VERNEMQ_KUBERNETES_NAMESPACE/pods?labelSelector=$DOCKER_VERNEMQ_KUBERNETES_LABEL_SELECTOR -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" | jq '.items[0].spec.subdomain' | sed 's/"//g' | tr '\n' '\0')}
+    VERNEMQ_KUBERNETES_SUBDOMAIN=${DOCKER_VERNEMQ_KUBERNETES_SUBDOMAIN:-$(curl -X GET $insecure --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt https://kubernetes.default.svc.$DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME/api/v1/namespaces/$DOCKER_VERNEMQ_KUBERNETES_NAMESPACE/pods?labelSelector=$DOCKER_VERNEMQ_KUBERNETES_LABEL_SELECTOR -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" | jq '.items[0].spec.subdomain' | sed 's/"//g' | tr '\n' '\0')}
     if [ $VERNEMQ_KUBERNETES_SUBDOMAIN == "null" ]; then
         VERNEMQ_KUBERNETES_HOSTNAME=${MY_POD_NAME}.${DOCKER_VERNEMQ_KUBERNETES_NAMESPACE}.svc.${DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME}
     else

--- a/bin/vernemq.sh
+++ b/bin/vernemq.sh
@@ -49,7 +49,7 @@ if env | grep "DOCKER_VERNEMQ_DISCOVERY_KUBERNETES" -q; then
     # Let's get the namespace if it isn't set
     DOCKER_VERNEMQ_KUBERNETES_NAMESPACE=${DOCKER_VERNEMQ_KUBERNETES_NAMESPACE:-`cat /var/run/secrets/kubernetes.io/serviceaccount/namespace`}
     # Let's set our nodename correctly
-    VERNEMQ_KUBERNETES_SUBDOMAIN=$(curl -X GET $insecure --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt https://kubernetes.default.svc.$DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME/api/v1/namespaces/$DOCKER_VERNEMQ_KUBERNETES_NAMESPACE/pods?labelSelector=$DOCKER_VERNEMQ_KUBERNETES_LABEL_SELECTOR -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" | jq '.items[0].spec.subdomain' | sed 's/"//g' | tr '\n' '\0')
+    VERNEMQ_KUBERNETES_SUBDOMAIN=${DOCKER_VERNEMQ_KUBERNETES_SUBDOMAIN:(curl -X GET $insecure --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt https://kubernetes.default.svc.$DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME/api/v1/namespaces/$DOCKER_VERNEMQ_KUBERNETES_NAMESPACE/pods?labelSelector=$DOCKER_VERNEMQ_KUBERNETES_LABEL_SELECTOR -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" | jq '.items[0].spec.subdomain' | sed 's/"//g' | tr '\n' '\0')}
     if [ $VERNEMQ_KUBERNETES_SUBDOMAIN == "null" ]; then
         VERNEMQ_KUBERNETES_HOSTNAME=${MY_POD_NAME}.${DOCKER_VERNEMQ_KUBERNETES_NAMESPACE}.svc.${DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME}
     else

--- a/bin/vernemq.sh
+++ b/bin/vernemq.sh
@@ -55,6 +55,7 @@ fi
 
 if [ -f /vernemq/etc/vernemq.conf.local ]; then
     cp /vernemq/etc/vernemq.conf.local /vernemq/etc/vernemq.conf
+    sed -i -r "s/###IPADDRESS###/${IP_ADDRESS}/" /vernemq/etc/vernemq.conf
 else
     sed -i '/########## Start ##########/,/########## End ##########/d' /vernemq/etc/vernemq.conf
 

--- a/bin/vernemq.sh
+++ b/bin/vernemq.sh
@@ -49,7 +49,7 @@ if env | grep "DOCKER_VERNEMQ_DISCOVERY_KUBERNETES" -q; then
     # Let's get the namespace if it isn't set
     DOCKER_VERNEMQ_KUBERNETES_NAMESPACE=${DOCKER_VERNEMQ_KUBERNETES_NAMESPACE:-`cat /var/run/secrets/kubernetes.io/serviceaccount/namespace`}
     # Let's set our nodename correctly
-    VERNEMQ_KUBERNETES_SUBDOMAIN=${DOCKER_VERNEMQ_KUBERNETES_SUBDOMAIN:(curl -X GET $insecure --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt https://kubernetes.default.svc.$DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME/api/v1/namespaces/$DOCKER_VERNEMQ_KUBERNETES_NAMESPACE/pods?labelSelector=$DOCKER_VERNEMQ_KUBERNETES_LABEL_SELECTOR -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" | jq '.items[0].spec.subdomain' | sed 's/"//g' | tr '\n' '\0')}
+    VERNEMQ_KUBERNETES_SUBDOMAIN=${DOCKER_VERNEMQ_KUBERNETES_SUBDOMAIN:-(curl -X GET $insecure --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt https://kubernetes.default.svc.$DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME/api/v1/namespaces/$DOCKER_VERNEMQ_KUBERNETES_NAMESPACE/pods?labelSelector=$DOCKER_VERNEMQ_KUBERNETES_LABEL_SELECTOR -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" | jq '.items[0].spec.subdomain' | sed 's/"//g' | tr '\n' '\0')}
     if [ $VERNEMQ_KUBERNETES_SUBDOMAIN == "null" ]; then
         VERNEMQ_KUBERNETES_HOSTNAME=${MY_POD_NAME}.${DOCKER_VERNEMQ_KUBERNETES_NAMESPACE}.svc.${DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME}
     else

--- a/helm/vernemq/Chart.yaml
+++ b/helm/vernemq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-appVersion: 1.8.0
+appVersion: 1.9.0
 description: VerneMQ is a high-performance, distributed MQTT message broker
 name: vernemq
-version: 1.3.0
+version: 1.4.0
 icon: http://www.stickpng.com/assets/thumbs/58482b21cef1014c0b5e4a24.png

--- a/helm/vernemq/Chart.yaml
+++ b/helm/vernemq/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: 1.9.1
 description: VerneMQ is a high-performance, distributed MQTT message broker
 name: vernemq
-version: 1.4.1
+version: 1.4.2
 icon: http://www.stickpng.com/assets/thumbs/58482b21cef1014c0b5e4a24.png

--- a/helm/vernemq/Chart.yaml
+++ b/helm/vernemq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-appVersion: 1.9.0
+appVersion: 1.9.1
 description: VerneMQ is a high-performance, distributed MQTT message broker
 name: vernemq
-version: 1.4.0
+version: 1.4.1
 icon: http://www.stickpng.com/assets/thumbs/58482b21cef1014c0b5e4a24.png

--- a/helm/vernemq/Chart.yaml
+++ b/helm/vernemq/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: 1.9.2
 description: VerneMQ is a high-performance, distributed MQTT message broker
 name: vernemq
-version: 1.4.3
+version: 1.4.4
 icon: http://www.stickpng.com/assets/thumbs/58482b21cef1014c0b5e4a24.png

--- a/helm/vernemq/Chart.yaml
+++ b/helm/vernemq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-appVersion: 1.7.1-1
+appVersion: 1.8.0
 description: VerneMQ is a high-performance, distributed MQTT message broker
 name: vernemq
-version: 1.2.0
+version: 1.3.0
 icon: http://www.stickpng.com/assets/thumbs/58482b21cef1014c0b5e4a24.png

--- a/helm/vernemq/Chart.yaml
+++ b/helm/vernemq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-appVersion: 1.9.1
+appVersion: 1.9.2
 description: VerneMQ is a high-performance, distributed MQTT message broker
 name: vernemq
-version: 1.4.2
+version: 1.4.3
 icon: http://www.stickpng.com/assets/thumbs/58482b21cef1014c0b5e4a24.png

--- a/helm/vernemq/README.md
+++ b/helm/vernemq/README.md
@@ -53,7 +53,7 @@ Parameter | Description | Default
 `additionalEnv` | additional environment variables | see [values.yaml](values.yaml)
 `image.pullPolicy` | container image pull policy | `IfNotPresent`
 `image.repository` | container image repository | `erlio/docker-vernemq`
-`image.tag` | container image tag | the current versions (e.g. `1.8.0`)
+`image.tag` | container image tag | the current versions (e.g. `1.9.0`)
 `nodeSelector` | node labels for pod assignment | `{}`
 `persistentVolume.accessModes` | data Persistent Volume access modes | `[ReadWriteOnce]`
 `persistentVolume.annotations` | annotations for Persistent Volume Claim | `{}`

--- a/helm/vernemq/README.md
+++ b/helm/vernemq/README.md
@@ -60,6 +60,7 @@ Parameter | Description | Default
 `persistentVolume.enabled` | if true, create a Persistent Volume Claim | `true`
 `persistentVolume.size` | data Persistent Volume size | `5Gi`
 `persistentVolume.storageClass` | data Persistent Volume Storage Class | `unset`
+`secretMounts` | mounts a secret as a file inside the statefulset. Useful for mounting certificates and other secrets.| `[]`
 `podAntiAffinity` | pod anti affinity, `soft` for trying not to run pods on the same nodes, `hard` to force kubernetes not to run 2 pods on the same node | `soft`
 `rbac.create` | if true, create & use RBAC resources | `true`
 `rbac.serviceAccount.create` | if true, create a serviceAccount | `true`

--- a/helm/vernemq/README.md
+++ b/helm/vernemq/README.md
@@ -53,7 +53,7 @@ Parameter | Description | Default
 `additionalEnv` | additional environment variables | see [values.yaml](values.yaml)
 `image.pullPolicy` | container image pull policy | `IfNotPresent`
 `image.repository` | container image repository | `erlio/docker-vernemq`
-`image.tag` | container image tag | the current versions (e.g. `1.9.1`)
+`image.tag` | container image tag | the current versions (e.g. `1.9.2`)
 `nodeSelector` | node labels for pod assignment | `{}`
 `persistentVolume.accessModes` | data Persistent Volume access modes | `[ReadWriteOnce]`
 `persistentVolume.annotations` | annotations for Persistent Volume Claim | `{}`

--- a/helm/vernemq/README.md
+++ b/helm/vernemq/README.md
@@ -53,7 +53,7 @@ Parameter | Description | Default
 `additionalEnv` | additional environment variables | see [values.yaml](values.yaml)
 `image.pullPolicy` | container image pull policy | `IfNotPresent`
 `image.repository` | container image repository | `erlio/docker-vernemq`
-`image.tag` | container image tag | the current versions (e.g. `1.7.1`)
+`image.tag` | container image tag | the current versions (e.g. `1.8.0`)
 `nodeSelector` | node labels for pod assignment | `{}`
 `persistentVolume.accessModes` | data Persistent Volume access modes | `[ReadWriteOnce]`
 `persistentVolume.annotations` | annotations for Persistent Volume Claim | `{}`

--- a/helm/vernemq/README.md
+++ b/helm/vernemq/README.md
@@ -53,7 +53,7 @@ Parameter | Description | Default
 `additionalEnv` | additional environment variables | see [values.yaml](values.yaml)
 `image.pullPolicy` | container image pull policy | `IfNotPresent`
 `image.repository` | container image repository | `erlio/docker-vernemq`
-`image.tag` | container image tag | the current versions (e.g. `1.9.0`)
+`image.tag` | container image tag | the current versions (e.g. `1.9.1`)
 `nodeSelector` | node labels for pod assignment | `{}`
 `persistentVolume.accessModes` | data Persistent Volume access modes | `[ReadWriteOnce]`
 `persistentVolume.annotations` | annotations for Persistent Volume Claim | `{}`

--- a/helm/vernemq/README.md
+++ b/helm/vernemq/README.md
@@ -53,7 +53,7 @@ Parameter | Description | Default
 `additionalEnv` | additional environment variables | see [values.yaml](values.yaml)
 `image.pullPolicy` | container image pull policy | `IfNotPresent`
 `image.repository` | container image repository | `erlio/docker-vernemq`
-`image.tag` | container image tag | the current versions (e.g. `1.9.2`)
+`image.tag` | container image tag | the current versions (e.g. `1.9.2-1`)
 `nodeSelector` | node labels for pod assignment | `{}`
 `persistentVolume.accessModes` | data Persistent Volume access modes | `[ReadWriteOnce]`
 `persistentVolume.annotations` | annotations for Persistent Volume Claim | `{}`

--- a/helm/vernemq/README.md
+++ b/helm/vernemq/README.md
@@ -110,3 +110,110 @@ $ helm install vernemq/vernemq --name my-release -f values.yaml
 Roles and RoleBindings resources will be created automatically.
 
 To manually setup RBAC you need to set the parameter `rbac.create=false` and specify the service account to be used for each service by setting the parameters: `serviceAccounts.create` to `false` and `serviceAccounts.name` to the name of a pre-existing service account.
+
+### Enable MQTTS
+
+If you would like to enable MQTTS, follow these steps:
+
+1. (a) Issue a certificate using Cert-Manager **OR** (b) Create secret resource using existing certificates.
+2. Set the parameter `service.mqtts.enabled=true`.
+3. Mount the certificate secret inside the statefulset.
+4. Set the environment variables for the SSL listener.
+
+#### (a) Issue a certificate using Cert-Manager
+[Cert-Manager](https://github.com/jetstack/cert-manager) is a Kubernetes add-on. It can issue, renew and revoke a certificate from various issuing sources automatically. Cert-Manager obtains certificates from an ACME server (e.g., Let’s Encrypt) using ACME protocol.
+
+You need to issue a new certificate. The issued certificate will be stored as secret `vernemq-certificates-secret` under the `default` namespace. The secret will be available to be mounted to the statefulset. See the example below:
+
+```bash
+cat <<EOF > vernemq-certificates.yaml
+---
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: vernemq-certificates
+  namespace: default
+spec:
+  secretName: vernemq-certificates-secret
+  issuerRef:
+    kind: ClusterIssuer
+    name: letsencrypt-staging
+  commonName: mqtt.vernemq.com
+  dnsNames:
+  - mqtt.vernemq.com
+  acme:
+    config:
+    - dns01:
+        provider: digitalocean-dns
+      domains:
+      - mqtt.vernemq.com
+EOF
+
+kubectl apply -f vernemq-certificates.yaml
+# output: certificate.certmanager.k8s.io/vernemq-certificates created
+```
+
+#### (b) Create secret resource using existing certificates
+
+Using the key and crt files, you can create a secret. Kubernetes stores these files as a base64 string, so the first step is to encode them.
+
+```bash
+$ cat ca.crt| base64
+LS0tLS1CRUdJTiBDRVJUSUZJQ...CBDRVJUSUZJQ0FURS0tLS0t
+$ cat tls.crt | base64
+LS0tLS1CRUdJTiBDRVJUSUZJQ...gQ0VSVElGSUNBVEUtLS0tLQo=
+$ cat tls.key | base64
+LS0tLS1CRUdJTiBSU0EgUFJJV...gUFJJVkFURSBLRVktLS0tLQo=
+```
+
+Now you can create a kubernetes resource definition (YAML) that will create the secret resource.
+
+```bash
+cat <<EOF > vernemq-certificates-secret.yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vernemq-certificates-secret
+  namespace: default
+type: kubernetes.io/tls
+data:
+  ca.crt:LS0tLS1CRUdJTiBDRVJUSUZJQ...CBDRVJUSUZJQ0FURS0tLS0t
+  tls.crt:LS0tLS1CRUdJTiBDRVJUSUZJQ...gQ0VSVElGSUNBVEUtLS0tLQo=
+  tls.key:LS0tLS1CRUdJTiBSU0EgUFJJV...gUFJJVkFURSBLRVktLS0tLQo=
+EOF
+
+kubectl apply -f vernemq-certificates-secret.yaml
+# output: secret "vernemq-certificates-secret" created
+```
+
+#### Mount the certificate secret inside the statefulset
+
+Inside `values.yaml` you can declared the mount path and the secret using the `secretMounts` parameter. For example:
+
+```yaml
+...
+secretMounts:
+  - name: vernemq-certificates
+    secretName: vernemq-certificates-secret
+    path: /etc/ssl/vernemq
+...
+```
+
+#### Set the environment variables for the SSL listener
+
+The exact path of the certificates can be declared inside `values.yaml` under `additionalEnv` parameter. For example:
+
+```yaml
+additionalEnv:
+...
+  - name: DOCKER_VERNEMQ_LISTENER__SSL__CAFILE
+    value: "/etc/ssl/vernemq/tls.crt"
+  - name: DOCKER_VERNEMQ_LISTENER__SSL__CERTFILE
+    value: "/etc/ssl/vernemq/tls.crt"
+  - name: DOCKER_VERNEMQ_LISTENER__SSL__KEYFILE
+    value: "/etc/ssl/vernemq/tls.key"
+...
+```
+
+> **Tip**: Cert-Manager includes both CA and TLS certificate in the `tls.crt` file.

--- a/helm/vernemq/templates/NOTES.txt
+++ b/helm/vernemq/templates/NOTES.txt
@@ -13,5 +13,5 @@
   echo $SERVICE_IP:1883
 {{- else if contains "ClusterIP" .Values.service.type }}
   echo "Subscribe/publish MQTT messages there: 127.0.0.1:1883"
-  kubectl port-forward svc/{{ .Release.Name }}-{{ include "vernemq.name" . }} 1883:1883
+  kubectl port-forward svc/{{ include "vernemq.fullname" . }} 1883:1883
 {{- end }}

--- a/helm/vernemq/templates/NOTES.txt
+++ b/helm/vernemq/templates/NOTES.txt
@@ -12,6 +12,6 @@
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "vernemq.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo $SERVICE_IP:1883
 {{- else if contains "ClusterIP" .Values.service.type }}
-  echo "Subscribe/publish MQTT messages there: 127.0.0.1:1883"
+  Subscribe/publish MQTT messages there: 127.0.0.1:1883
   kubectl port-forward svc/{{ include "vernemq.fullname" . }} 1883:1883
 {{- end }}

--- a/helm/vernemq/templates/NOTES.txt
+++ b/helm/vernemq/templates/NOTES.txt
@@ -1,5 +1,5 @@
 1. Check your VerneMQ cluster status:
-  kubectl exec --namespace {{ .Release.Namespace }} {{ .Release.Name }}-{{ include "vernemq.name" . }}-0 /usr/sbin/vmq-admin cluster show
+  kubectl exec --namespace {{ .Release.Namespace }} {{ .Release.Name }}-{{ include "vernemq.name" . }}-0 /vernemq/bin/vmq-admin cluster show
 
 2. Get VerneMQ MQTT port
 {{- if contains "NodePort" .Values.service.type }}

--- a/helm/vernemq/templates/NOTES.txt
+++ b/helm/vernemq/templates/NOTES.txt
@@ -1,5 +1,5 @@
 1. Check your VerneMQ cluster status:
-  kubectl exec --namespace {{ .Release.Namespace }} {{ .Release.Name }}-{{ include "vernemq.name" . }}-0 /vernemq/bin/vmq-admin cluster show
+  kubectl exec --namespace {{ .Release.Namespace }} {{ .Chart.Name }}-0 /vernemq/bin/vmq-admin cluster show
 
 2. Get VerneMQ MQTT port
 {{- if contains "NodePort" .Values.service.type }}

--- a/helm/vernemq/templates/statefulset.yaml
+++ b/helm/vernemq/templates/statefulset.yaml
@@ -61,6 +61,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
             - name: DOCKER_VERNEMQ_DISCOVERY_KUBERNETES
               value: "1"
             - name: DOCKER_VERNEMQ_KUBERNETES_LABEL_SELECTOR
@@ -68,6 +72,10 @@ spec:
             {{- /* Add this localhost listener in order to get the port forwarding working */}}
             - name: DOCKER_VERNEMQ_LISTENER__TCP__LOCALHOST
               value: "127.0.0.1:1883"
+            {{- if .Values.service.mqtts.enabled }}
+            - name: DOCKER_VERNEMQ_LISTENER__SSL__DEFAULT
+              value: "$(MY_POD_IP):{{ .Values.service.mqtts.port }}"
+            {{- end }}
             {{ toYaml .Values.additionalEnv | nindent 12 }}
           resources:
             {{ toYaml .Values.resources | nindent 12 }}
@@ -98,6 +106,11 @@ spec:
               mountPath: /vernemq/log
             - name: data
               mountPath: /vernemq/data
+            {{- range .Values.secretMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .path }}
+              readOnly: true
+            {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
         {{ toYaml . | nindent 8 }}
@@ -144,6 +157,11 @@ spec:
       volumes:
         - name: logs
           emptyDir: {}
+        {{- range .Values.secretMounts }}
+        - name: {{ .name }}
+          secret:
+            secretName: {{ .secretName }}
+        {{- end }}
 {{- if .Values.persistentVolume.enabled }}
   volumeClaimTemplates:
     - metadata:

--- a/helm/vernemq/values.yaml
+++ b/helm/vernemq/values.yaml
@@ -105,6 +105,13 @@ persistentVolume:
   ## Annotations for Persistent Volume Claim
   annotations: {}
 
+# A list of secrets and their paths to mount inside the pod
+# This is useful for mounting certificates for security (tls)
+secretMounts: []
+#  - name: vernemq-certificates
+#    secretName: vernemq-certificates-secret
+#    path: /etc/ssl/vernemq
+
 statefulset:
   ## Start and stop pods in Parallel or OrderedReady (one-by-one.)  Note - Can not change after first release.
   ## Ref: https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#pod-management-policy
@@ -154,3 +161,9 @@ additionalEnv:
 #    value: "10000"
 #  - name: DOCKER_VERNEMQ_MAX_OFFLINE_MESSAGES
 #    value: "-1"
+#  - name: DOCKER_VERNEMQ_LISTENER__SSL__CAFILE
+#    value: "/etc/ssl/vernemq/tls.crt"
+#  - name: DOCKER_VERNEMQ_LISTENER__SSL__CERTFILE
+#    value: "/etc/ssl/vernemq/tls.crt"
+#  - name: DOCKER_VERNEMQ_LISTENER__SSL__KEYFILE
+#    value: "/etc/ssl/vernemq/tls.key"

--- a/helm/vernemq/values.yaml
+++ b/helm/vernemq/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: erlio/docker-vernemq
-  tag: 1.9.0-alpine
+  tag: 1.9.1-alpine
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/helm/vernemq/values.yaml
+++ b/helm/vernemq/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: erlio/docker-vernemq
-  tag: 1.8.0-alpine
+  tag: 1.9.0-alpine
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/helm/vernemq/values.yaml
+++ b/helm/vernemq/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: erlio/docker-vernemq
-  tag: 1.7.1-2-alpine
+  tag: 1.8.0-alpine
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/helm/vernemq/values.yaml
+++ b/helm/vernemq/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: erlio/docker-vernemq
-  tag: 1.9.2-alpine
+  tag: 1.9.2-1-alpine
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/helm/vernemq/values.yaml
+++ b/helm/vernemq/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: erlio/docker-vernemq
-  tag: 1.9.1-alpine
+  tag: 1.9.2-alpine
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/helm/vernemq/values.yaml
+++ b/helm/vernemq/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: erlio/docker-vernemq
-  tag: 1.7.1-1-alpine
+  tag: 1.7.1-2-alpine
   pullPolicy: IfNotPresent
 
 nameOverride: ""


### PR DESCRIPTION
This is more a maintenance update rather than a priority one, but we’re lagging behind

The complete VerneMQ changelog can be read here: https://github.com/vernemq/vernemq/blob/master/changelog.md

Most of the recent stuff is MQTT5/webhooks related, but some 1.8 updates are also interesting: (personal selection below):
- Fix vmq_diversity cache invalidation timing issue when a client reconnects right after a disconnect 
- Make it possible to configure how many concurrent bcrypt operations are possible via the vmq_bcrypt.pool_size config
